### PR TITLE
[Transport] Convert error if domain uri is unparsable.

### DIFF
--- a/src/transport.rs
+++ b/src/transport.rs
@@ -184,7 +184,9 @@ impl Transport {
             }
             #[cfg(feature = "unix-socket")]
             Transport::Unix { ref path, .. } => {
-                let uri: hyper::Uri = DomainUri::new(&path, endpoint.as_ref()).into();
+                let uri : hyper::Uri = DomainUri::new(&path, endpoint.as_ref())
+                    .map(DomainUri::into)
+                    .map_err(|error| Error::from(http::Error::from(error)))?;
                 builder.method(method).uri(&uri.to_string())
             }
         };


### PR DESCRIPTION
I tried to use your branch for a small proof of concept demo and realized that it currently doesn't compile as soon as the `unix_socket` feature is enabled. The reason is a missing error conversion.

Next to this everything seems to work like a charm. Thanks for your great work!